### PR TITLE
additive_summary_plot() removes duplicate rows for efficiency

### DIFF
--- a/R/additive_summary_plot.R
+++ b/R/additive_summary_plot.R
@@ -10,6 +10,7 @@
 additive_summary_plot <- function(additive_summary, ribbonFill = "grey80") {
 
   additive_summary$gamDf %>%
+    distinct() %>%
     ggplot() +
     geom_hline(yintercept = 0) +
     geom_ribbon(aes(x_j, ymin = fx_j_lo, ymax = fx_j_hi),


### PR DESCRIPTION
Small suggested change: removing duplicate rows with `distinct()` before plotting to speed plot generation/rendering/saving by eliminating overplotting. 

In my tests I was getting 3x+ speed increases in operations with this.